### PR TITLE
Move phpunit to "require-dev".

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "php": ">=5.3.2",
         "symfony/console": ">=2.0.10",
         "symfony/process": ">=2.0.10",
-        "andrewsville/php-token-reflection": ">=1.3.0",
+        "andrewsville/php-token-reflection": ">=1.3.0"
+    },
+    "require-dev": {
         "phpunit/phpunit": ">=1.6"
     },
     "autoload": {


### PR DESCRIPTION
PHPUnit is not needed by the runtime library. It is only needed to run the
unit tests when developing the library. This change allows phpunit to be
installed by composer when `composer install --dev` is run but keeps it from being
installed when a user is including sphpdox in their own project's
composer.json file.
