### PR TITLE
Support phpdomain `php:interface` and `php:trait`

### DIFF
--- a/lib/Sphpdox/Element/ClassElement.php
+++ b/lib/Sphpdox/Element/ClassElement.php
@@ -57,7 +57,15 @@ class ClassElement extends Element
         $string .= $title . "\n";
         $string .= str_repeat('-', strlen($title)) . "\n\n";
         $string .= $this->getNamespaceElement();
-        $string .= '.. php:class:: ' . $this->reflection->getShortName();
+        
+        if ($this->reflection->isInterface()){
+        	$string .= '.. php:interface:: ' ;
+        } elseif ($this->reflection->isTrait()){
+        	$string .= '.. php:trait:: ' ;
+        } else {
+        	$string .= '.. php:class:: ' ;
+        }
+        $string .= $this->reflection->getShortName();
 
         $parser = $this->getParser();
 


### PR DESCRIPTION
Hi,

great work! I needed the script to export `php:interface` and `php:trait` as well. This commit worked for me to do that, don't know if there's more to do.

Best regards...